### PR TITLE
feat: switch to npm-based theme with container-first build

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches: [main]
     paths-ignore: ['**.md']
+  schedule:
+    - cron: '0 6 * * *'
+  repository_dispatch:
+    types: [rebuild-image]
 
 jobs:
   build:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,6 @@
 FROM node:22-alpine AS builder
 WORKDIR /app
 
-RUN apk add --no-cache git
-
 # Install deps (cached layer)
 COPY package*.json ./
 RUN npm ci

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -4,10 +4,12 @@ set -e
 CONTENT_DIR="${CONTENT_DIR:-/content/docs}"
 OUTPUT_DIR="${OUTPUT_DIR:-/output}"
 
-# Clone theme if not mounted/present
-if [ ! -d "/app/theme" ]; then
-  git clone --depth 1 https://github.com/robinmordasiewicz/f5xc-docs-theme.git /app/theme
-fi
+# Update dependencies to latest versions
+npm install
+npm update
+
+# Copy Astro config from theme package
+cp /app/node_modules/f5xc-docs-theme/astro.config.mjs /app/astro.config.mjs
 
 # Inject content
 if [ -d "$CONTENT_DIR" ]; then
@@ -21,6 +23,12 @@ fi
 if [ -z "$DOCS_TITLE" ] && [ -f /app/src/content/docs/index.mdx ]; then
   DOCS_TITLE=$(grep -m1 '^title:' /app/src/content/docs/index.mdx | sed 's/title: *["]*//;s/["]*$//' || echo "Documentation")
   export DOCS_TITLE
+fi
+
+# Extract base path from repo name (if not set via env)
+if [ -z "$DOCS_BASE" ] && [ -n "$GITHUB_REPOSITORY" ]; then
+  DOCS_BASE="/${GITHUB_REPOSITORY#*/}"
+  export DOCS_BASE
 fi
 
 # Build

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "docs-builder",
+  "name": "f5xc-docs-builder",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "docs-builder",
+      "name": "f5xc-docs-builder",
       "version": "1.0.0",
       "dependencies": {
         "@astrojs/react": "^4.4.2",
@@ -13,6 +13,7 @@
         "@types/react": "^19.2.13",
         "@types/react-dom": "^19.2.3",
         "astro": "^5.17.1",
+        "f5xc-docs-theme": "npm:@robinmordasiewicz/f5xc-docs-theme@^1.1.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "sharp": "^0.34.5",
@@ -135,6 +136,7 @@
       "resolved": "https://registry.npmjs.org/@astrojs/starlight/-/starlight-0.37.6.tgz",
       "integrity": "sha512-wQrKwH431q+8FsLBnNQeG+R36TMtEGxTQ2AuiVpcx9APcazvL3n7wVW8mMmYyxX0POjTnxlcWPkdMGR3Yj1L+w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@astrojs/markdown-remark": "^6.3.1",
         "@astrojs/mdx": "^4.2.3",
@@ -3344,6 +3346,16 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/f5xc-docs-theme": {
+      "name": "@robinmordasiewicz/f5xc-docs-theme",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@robinmordasiewicz/f5xc-docs-theme/-/f5xc-docs-theme-1.2.0.tgz",
+      "integrity": "sha512-sGvyn6ro+yh3gqj0Ye2ZFHfcu9sZUotsJx3lqnIHS1farFjT/Ij4cZLuG+5hXVUgLphkdFQNqwAK3swoE22/pA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@astrojs/starlight": ">=0.34.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -5983,6 +5995,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
       "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "astro": "astro"
   },
   "dependencies": {
+    "f5xc-docs-theme": "npm:@robinmordasiewicz/f5xc-docs-theme@^1.1.0",
     "@astrojs/react": "^4.4.2",
     "@astrojs/starlight": "^0.37.6",
     "@types/react": "^19.2.13",


### PR DESCRIPTION
## Summary
- Add `f5xc-docs-theme` as aliased npm dependency
- Remove `git` from Dockerfile (no longer needed)
- Entrypoint runs `npm install` + `npm update` at runtime for latest versions
- Entrypoint copies `astro.config.mjs` from installed theme package
- Entrypoint auto-extracts `DOCS_BASE` from `GITHUB_REPOSITORY`
- Build workflow adds daily cron schedule + `repository_dispatch` trigger

## Test plan
- [ ] Verify image builds successfully after merge
- [ ] Run container with sample content and confirm theme loads
- [ ] Confirm `astro.config.mjs` is copied from `node_modules/f5xc-docs-theme/`
- [ ] Verify DOCS_BASE auto-extraction from GITHUB_REPOSITORY

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)