### PR TITLE
fix: patch customCss bug, add multi-arch build, upgrade to Node 24

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -16,6 +16,8 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v5
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -26,6 +28,7 @@ jobs:
           context: .
           file: docker/Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/${{ github.repository }}:latest
             ghcr.io/${{ github.repository }}:${{ github.sha }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 .env
 .env.*
 *.log
+astro.config.mjs

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine AS builder
+FROM node:24-alpine AS builder
 WORKDIR /app
 
 # Install deps (cached layer)

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -11,6 +11,9 @@ npm update
 # Copy Astro config from theme package
 cp /app/node_modules/f5xc-docs-theme/astro.config.mjs /app/astro.config.mjs
 
+# Patch: ensure customCss is initialized (workaround for theme plugin bug)
+sed -i "s/title: process.env.DOCS_TITLE || 'Documentation',/title: process.env.DOCS_TITLE || 'Documentation',\n      customCss: [],/" /app/astro.config.mjs
+
 # Inject content
 if [ -d "$CONTENT_DIR" ]; then
   cp -r "$CONTENT_DIR"/* /app/src/content/docs/


### PR DESCRIPTION
## Summary
- Patch `docker/entrypoint.sh` to inject `customCss: []` into the astro config after copying from theme, fixing the `config.customCss is not iterable` build error
- Add QEMU + Buildx to the Docker build workflow for `linux/amd64` and `linux/arm64` images (supports Mac M-series and ARM runners)
- Upgrade base image from `node:22-alpine` to `node:24-alpine`
- Add `astro.config.mjs` to `.gitignore` (generated file copied from theme at build time)

## Test plan
- [ ] CI passes on this PR
- [ ] Docker image builds for both amd64 and arm64 platforms
- [ ] Container runs `astro build` successfully without `customCss` error
- [ ] Pull and run image on Apple Silicon Mac to verify ARM support

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)