### PR TITLE
fix: add packages:read permission to pages deploy workflow

### DIFF
--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
   pages: write
   id-token: write
 


### PR DESCRIPTION
## Summary
- Add `packages: read` permission to the GitHub Pages Deploy caller workflow
- The reusable workflow at `f5xc-template` needs this to pull the builder Docker image from GHCR
- Without it, the restricted caller permissions cause a `startup_failure` with no jobs running

## Test plan
- [ ] CI passes on this PR
- [ ] GitHub Pages Deploy workflow runs successfully after merge

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)