### PR TITLE
fix: add docs directory so Pages deploy workflow has content

### DIFF
--- a/docs/01-architecture.mdx
+++ b/docs/01-architecture.mdx
@@ -1,0 +1,109 @@
+---
+title: Architecture
+description: System design, directory layout, theme system, and build pipeline for the f5xc docs builder.
+---
+
+## Overview
+
+The f5xc docs builder is a containerized [Astro](https://astro.build/) + [Starlight](https://starlight.astro.build/) system. Content repos provide Markdown/MDX files; the builder supplies the framework, theme, and build logic. The two halves meet at build time inside a Docker container.
+
+## Content Injection Model
+
+Content repos keep their documentation in a `docs/` directory. At build time the container copies those files into `src/content/docs/`, where Astro's content collection picks them up.
+
+```
+content-repo/
+  docs/           ← authored by content teams
+    index.mdx
+    guide.mdx
+
+f5xc-docs-builder/
+  src/content/docs/ ← empty at rest (.gitkeep)
+```
+
+The entrypoint script (`docker/entrypoint.sh`) performs the copy:
+
+```sh
+cp -r "$CONTENT_DIR"/* /app/src/content/docs/
+```
+
+This means the builder repo itself ships with an empty `src/content/docs/` directory. Content only appears at build time.
+
+## Theme System
+
+The Starlight theme is published as a separate npm package. `package.json` uses an npm alias to map a short name to the scoped registry package:
+
+```json
+"f5xc-docs-theme": "npm:@robinmordasiewicz/f5xc-docs-theme@^1.1.0"
+```
+
+The theme package owns `astro.config.mjs`. At build time the entrypoint copies it into the project root:
+
+```sh
+cp /app/node_modules/f5xc-docs-theme/astro.config.mjs /app/astro.config.mjs
+```
+
+This keeps configuration centralized — content repos and the builder itself do not maintain their own Astro config.
+
+## Source Directory Layout
+
+```
+src/
+  components/
+    PlaceholderForm.tsx          # React form for editing placeholder values
+    PlaceholderFormWrapper.astro # Astro wrapper, loads DOM script and global CSS
+  content/
+    docs/                        # Mount point for injected content
+  content.config.ts              # Starlight content collection definition
+  data/
+    placeholders.json            # Placeholder token definitions
+  lib/
+    placeholder-store.ts         # State management: load, save, compute, emit
+  plugins/
+    remark-mermaid.mjs           # Remark plugin: code blocks → mermaid containers
+  scripts/
+    placeholder-dom.ts           # Client-side DOM walker and Mermaid renderer
+```
+
+## Content Collection
+
+`src/content.config.ts` defines a single `docs` collection using Starlight's loader and schema:
+
+```ts
+import { defineCollection } from 'astro:content';
+import { docsLoader } from '@astrojs/starlight/loaders';
+import { docsSchema } from '@astrojs/starlight/schema';
+
+export const collections = {
+  docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
+};
+```
+
+Any `.md` or `.mdx` file placed in `src/content/docs/` becomes a page in the built site.
+
+## Build Flow
+
+The following diagram shows the end-to-end build pipeline when the Docker container runs:
+
+```mermaid
+flowchart LR
+    A[Content Repo<br/>docs/] -->|mount| B[Container<br/>/content/docs]
+    B -->|entrypoint.sh<br/>cp| C[src/content/docs/]
+    D[npm registry] -->|npm install| E[node_modules/<br/>f5xc-docs-theme]
+    E -->|cp astro.config| F[astro.config.mjs]
+    C --> G[astro build]
+    F --> G
+    G --> H[dist/<br/>static HTML]
+    H -->|cp| I[/output]
+```
+
+## Build-Time vs Client-Time Processing
+
+| Concern | When | How |
+|---------|------|-----|
+| MDX → HTML | Build time | Astro compiler |
+| Mermaid code blocks → container divs | Build time | `remark-mermaid.mjs` plugin |
+| Placeholder tokens → interactive spans | Client time | `placeholder-dom.ts` TreeWalker |
+| Mermaid SVG rendering | Client time | `mermaid` CDN import in `placeholder-dom.ts` |
+| Placeholder form state | Client time | `placeholder-store.ts` + localStorage |
+| Astro page transitions | Client time | `astro:page-load` event listener |

--- a/docs/02-placeholder-system.mdx
+++ b/docs/02-placeholder-system.mdx
@@ -1,0 +1,207 @@
+---
+title: Placeholder System
+description: Token format, state management, DOM walker, computed values, and how to add new placeholders.
+---
+
+The placeholder system lets readers customize IP addresses, ASNs, and other deployment-specific values throughout the documentation. Authors write tokens in their Markdown; the browser replaces them with user-supplied values at runtime.
+
+## Token Format
+
+Tokens follow the regex pattern:
+
+```
+x([A-Z][A-Z0-9_]+)x
+```
+
+A token starts and ends with a lowercase `x` and contains an uppercase identifier. For example, `xCUSTOMER_ASNx` references the `CUSTOMER_ASN` placeholder.
+
+The regex is defined in `src/scripts/placeholder-dom.ts`:
+
+```ts
+const PH_REGEX = /x([A-Z][A-Z0-9_]+)x/g;
+```
+
+## Placeholder Definitions
+
+All placeholders are declared in `src/data/placeholders.json`. Each entry has this shape:
+
+```json
+{
+  "CUSTOMER_ASN": {
+    "type": "text",
+    "default": "64496",
+    "description": "Your public ASN (registered with ARIN/RIR)"
+  }
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `type` | yes | `"text"` for free-form input, `"dropdown"` for select menus |
+| `default` | yes | Initial value shown before the reader changes anything |
+| `description` | yes | Label displayed in the form |
+| `options` | only for dropdown | Array of allowed values |
+
+## State Management
+
+`src/lib/placeholder-store.ts` handles all placeholder state.
+
+### Storage
+
+Values are persisted in `localStorage` under the key `f5xc-placeholders`. The store exposes four functions:
+
+| Function | Purpose |
+|----------|---------|
+| `getDefaults()` | Returns a map of every placeholder key to its `default` value from JSON |
+| `loadValues()` | Reads from localStorage, falls back to `getDefaults()` |
+| `saveValues(values)` | Writes the current map to localStorage |
+| `clearValues()` | Removes the localStorage entry |
+
+### Field Groups
+
+`FIELD_GROUPS` organizes placeholder keys into labeled sections for the form UI:
+
+```ts
+export const FIELD_GROUPS: FieldGroup[] = [
+  { label: 'Data Center & Scrubbing Centers', keys: ['DC_NAME', 'CENTER_1', 'CENTER_2'] },
+  { label: 'Protected Prefixes', keys: ['PROTECTED_CIDR_V4', 'PROTECTED_NET_V4', ...] },
+  { label: 'BGP', keys: ['CUSTOMER_ASN', 'F5_XC_ASN', 'BGP_PASSWORD'] },
+  // ... more groups
+];
+```
+
+### Computed Values
+
+Some values are derived from user input rather than entered directly. `getComputedValues()` calculates these from lookup tables:
+
+```ts
+const cidrToMask: Record<string, string> = {
+  '/24 (256 IPs)': '255.255.255.0',
+  '/23 (512 IPs)': '255.255.254.0',
+  // ...
+};
+```
+
+Two computed placeholders are produced:
+
+| Computed Key | Derived From | Example |
+|-------------|-------------|---------|
+| `PROTECTED_MASK_V4` | `PROTECTED_CIDR_V4` via `cidrToMask` lookup | `255.255.255.0` |
+| `PROTECTED_PREFIX_V4` | `PROTECTED_NET_V4` + `PROTECTED_CIDR_V4` via `cidrToShort` | `192.0.2.0/24` |
+
+`getAllValues()` merges user-entered values with computed values, giving a complete map for substitution.
+
+### Event Emission
+
+`emitChange()` dispatches a `placeholder-change` CustomEvent on `document` with the full value map as `detail`:
+
+```ts
+export function emitChange(values: Record<string, string>) {
+  document.dispatchEvent(
+    new CustomEvent('placeholder-change', { detail: getAllValues(values) }),
+  );
+}
+```
+
+This event drives both the DOM span updates and Mermaid re-rendering.
+
+## React Form Component
+
+`src/components/PlaceholderForm.tsx` provides the editing UI.
+
+- **State**: `useState` initialized from `loadValues()`
+- **On mount**: `useEffect` calls `emitChange()` to trigger the initial DOM substitution
+- **handleChange**: Updates React state, calls `saveValues()` and `emitChange()`
+- **handleReset**: Calls `clearValues()`, resets state to `getDefaults()`, emits change
+- **Rendering**: Iterates `FIELD_GROUPS`, rendering a `<fieldset>` per group. Each key gets either an `<input>` (text type) or `<select>` (dropdown type)
+- **Layout**: The form is wrapped in a `<details>` element, collapsed by default
+
+## Astro Wrapper
+
+`src/components/PlaceholderFormWrapper.astro` connects the React component to the Astro page:
+
+```astro
+<PlaceholderForm client:only="react" />
+
+<script>
+  import '../scripts/placeholder-dom.ts';
+</script>
+```
+
+`client:only="react"` tells Astro to hydrate the component purely on the client (no SSR). The `<script>` tag imports the DOM walker so it runs on every page that includes this wrapper.
+
+The wrapper also injects global CSS for form styling (`.ph-form-wrapper`, `.ph-grid`, `.ph-value`, etc.).
+
+## DOM Walker
+
+`src/scripts/placeholder-dom.ts` handles the client-side token replacement.
+
+### Initial Walk
+
+On page load, `init()` runs:
+
+1. Selects `.sl-markdown-content` as the root (falls back to `document.body`)
+2. Calls `walkTextNodes(root, values)` which uses `document.createTreeWalker` with `NodeFilter.SHOW_TEXT`
+3. For each text node matching the token regex, splits it into a document fragment of plain text nodes and `<span data-ph="KEY" class="ph-value">` elements
+4. Replaces the original text node with the fragment
+
+After the walk, the DOM contains spans with `data-ph` attributes instead of raw tokens.
+
+### Subsequent Updates
+
+When the form emits a `placeholder-change` event, `updateSpans()` runs:
+
+```ts
+document.querySelectorAll<HTMLSpanElement>('span[data-ph]').forEach((span) => {
+  const name = span.getAttribute('data-ph')!;
+  if (values[name] !== undefined) {
+    span.textContent = values[name];
+  }
+});
+```
+
+This avoids re-walking the tree — it directly updates the span text content.
+
+### Event Listeners
+
+The script registers two listeners:
+
+| Event | Handler | Purpose |
+|-------|---------|---------|
+| `placeholder-change` | `handleChange` | Updates spans and re-renders Mermaid diagrams |
+| `astro:page-load` | `init` | Re-walks the DOM after Astro client-side navigation |
+
+## How To: Add a New Placeholder
+
+1. **Add the JSON entry** in `src/data/placeholders.json`:
+   ```json
+   "MY_NEW_VALUE": {
+     "type": "text",
+     "default": "example",
+     "description": "Description shown in the form"
+   }
+   ```
+
+2. **Add the key to a field group** in `src/lib/placeholder-store.ts`. Either add it to an existing group's `keys` array or create a new group in `FIELD_GROUPS`.
+
+3. **Use the token in content**: Write `xMY_NEW_VALUEx` in any `.mdx` file. The DOM walker will replace it at runtime.
+
+## How To: Add a Computed Value
+
+Computed values are derived from other placeholders. To add one:
+
+1. Add a lookup table (if needed) in `src/lib/placeholder-store.ts`, following the pattern of `cidrToMask`.
+
+2. Extend `getComputedValues()` to include the new derived key:
+   ```ts
+   export function getComputedValues(values: Record<string, string>): Record<string, string> {
+     // ... existing logic
+     return {
+       PROTECTED_MASK_V4: mask,
+       PROTECTED_PREFIX_V4: `${net}${short}`,
+       MY_COMPUTED: derivedValue,  // add here
+     };
+   }
+   ```
+
+3. Use `xMY_COMPUTEDx` in content like any other token. Computed values do not need a `placeholders.json` entry or a field group — they are invisible to the form.

--- a/docs/03-mermaid.mdx
+++ b/docs/03-mermaid.mdx
@@ -1,0 +1,125 @@
+---
+title: Mermaid Diagrams
+description: Remark plugin, client-side CDN rendering, placeholder substitution in diagrams, and error handling.
+---
+
+The builder supports [Mermaid](https://mermaid.js.org/) diagrams with two-phase processing: a remark plugin at build time prepares the markup, and a client-side renderer produces the SVG.
+
+## Remark Plugin
+
+`src/plugins/remark-mermaid.mjs` runs during the Astro build. It uses `unist-util-visit` to find fenced code blocks with `lang === 'mermaid'` and replaces them with HTML:
+
+```js
+visit(tree, 'code', (node, index, parent) => {
+  if (node.lang !== 'mermaid' || index === undefined || !parent) return;
+
+  const escaped = node.value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+
+  parent.children[index] = {
+    type: 'html',
+    value: `<div class="mermaid-container" data-mermaid-src="${escaped}">
+              <pre class="mermaid">${node.value}</pre>
+            </div>`,
+  };
+});
+```
+
+Key details:
+
+| Aspect | Value |
+|--------|-------|
+| Node type matched | `code` nodes where `lang === 'mermaid'` |
+| HTML entity escaping | `&`, `<`, `>`, `"` — prevents attribute injection in `data-mermaid-src` |
+| Output structure | `<div class="mermaid-container">` with `data-mermaid-src` attribute holding the escaped source |
+| Fallback content | `<pre class="mermaid">` with the raw source (visible until JS renders) |
+
+## Client-Side Rendering
+
+The `renderMermaidDiagrams()` function in `src/scripts/placeholder-dom.ts` handles SVG generation in the browser.
+
+### Mermaid Import
+
+Mermaid is loaded on demand from a CDN — it is not bundled:
+
+```ts
+const mermaid = (await import('https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs')).default;
+```
+
+### Initialization
+
+```ts
+mermaid.initialize({
+  startOnLoad: false,
+  theme: 'default',
+  securityLevel: 'loose',
+  themeVariables: {
+    primaryColor: '#ffffff',
+    primaryBorderColor: '#cccccc',
+    background: '#ffffff',
+    mainBkg: '#ffffff',
+    secondBkg: '#ffffff',
+    tertiaryColor: '#ffffff',
+  },
+});
+```
+
+`startOnLoad: false` prevents Mermaid from auto-scanning the page. `securityLevel: 'loose'` allows click events and links in diagrams.
+
+### Render Loop
+
+For each `.mermaid-container` element:
+
+1. Read the raw diagram source from `data-mermaid-src`
+2. Run placeholder substitution on the source (see below)
+3. Clear the container and remove any `data-processed` attribute
+4. Call `mermaid.render()` with a random ID to produce SVG
+5. Set `backgroundColor: 'white'` on the rendered `<svg>` element
+
+## Placeholder Substitution in Diagrams
+
+Before rendering, the diagram source passes through the same `substituteText()` function used by the DOM walker (see [Placeholder System](/02-placeholder-system/) for the walker mechanism):
+
+```ts
+const template = container.getAttribute('data-mermaid-src') || '';
+const substituted = substituteText(template, values);
+```
+
+This means placeholder tokens like `xCUSTOMER_ASNx` work inside Mermaid diagram definitions. When a user changes a value in the form, the `placeholder-change` event triggers a full re-render of all diagrams with updated values.
+
+## Error Handling
+
+If `mermaid.render()` throws (for example, due to a syntax error in the diagram source), the catch block displays the error directly in the container:
+
+```ts
+} catch (e) {
+  container.textContent = `Diagram error: ${e}`;
+}
+```
+
+This makes authoring errors visible without breaking the rest of the page.
+
+## Re-rendering
+
+Diagrams re-render in two situations:
+
+| Trigger | Event | What happens |
+|---------|-------|-------------|
+| Placeholder value changes | `placeholder-change` | `handleChange()` calls `renderMermaidDiagrams()` with new values |
+| Astro page navigation | `astro:page-load` | `init()` calls `renderMermaidDiagrams()` for the new page |
+
+## Authoring Syntax
+
+Write a standard fenced code block with the `mermaid` language tag:
+
+````markdown
+```mermaid
+flowchart LR
+    A[Customer ASN: xCUSTOMER_ASNx] --> B[F5 XC ASN: xF5_XC_ASNx]
+```
+````
+
+The remark plugin converts this to a container div at build time. The client renders it as an SVG with placeholder values substituted.

--- a/docs/04-docker.mdx
+++ b/docs/04-docker.mdx
@@ -1,0 +1,153 @@
+---
+title: Docker Build
+description: Dockerfile layers, entrypoint orchestration, environment variables, and local usage.
+---
+
+The builder ships as a Docker image. Content repos run it to produce static HTML without installing Node.js or Astro locally.
+
+## Dockerfile
+
+`docker/Dockerfile` uses a multi-step build on `node:22-alpine`:
+
+```dockerfile
+FROM node:22-alpine AS builder
+WORKDIR /app
+
+# Install deps (cached layer)
+COPY package*.json ./
+RUN npm ci
+
+# Copy framework code
+COPY . .
+
+# Remove placeholder content
+RUN rm -rf src/content/docs/*
+
+COPY docker/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+```
+
+### Layer Strategy
+
+| Layer | What | Why cached separately |
+|-------|------|----------------------|
+| 1 | `COPY package*.json` + `npm ci` | Dependencies change infrequently; caching this layer avoids re-downloading on every build |
+| 2 | `COPY . .` | Framework source code |
+| 3 | `rm -rf src/content/docs/*` | Cleans out any placeholder content so only injected content appears |
+| 4 | `COPY entrypoint.sh` | Build orchestration script |
+
+## Entrypoint
+
+`docker/entrypoint.sh` runs each time the container starts. It performs these steps in order:
+
+### Step 1: Update Dependencies
+
+```sh
+npm install
+npm update
+```
+
+Ensures the theme package and all dependencies are at their latest compatible versions.
+
+### Step 2: Copy Theme Config
+
+```sh
+cp /app/node_modules/f5xc-docs-theme/astro.config.mjs /app/astro.config.mjs
+```
+
+Pulls `astro.config.mjs` from the theme package into the project root. This is the only Astro config the build uses — see [Architecture](/01-architecture/) for the theme system design.
+
+### Step 3: Inject Content
+
+```sh
+if [ -d "$CONTENT_DIR" ]; then
+  cp -r "$CONTENT_DIR"/* /app/src/content/docs/
+else
+  echo "ERROR: No content found at $CONTENT_DIR"
+  exit 1
+fi
+```
+
+Copies the mounted content into Astro's content collection directory. Exits with an error if the content directory is missing.
+
+### Step 4: Extract Title
+
+```sh
+if [ -z "$DOCS_TITLE" ] && [ -f /app/src/content/docs/index.mdx ]; then
+  DOCS_TITLE=$(grep -m1 '^title:' /app/src/content/docs/index.mdx | sed 's/title: *["]*//;s/["]*$//')
+  export DOCS_TITLE
+fi
+```
+
+If `DOCS_TITLE` is not set via environment, extracts it from the `title:` frontmatter field of `index.mdx`.
+
+### Step 5: Extract Base Path
+
+```sh
+if [ -z "$DOCS_BASE" ] && [ -n "$GITHUB_REPOSITORY" ]; then
+  DOCS_BASE="/${GITHUB_REPOSITORY#*/}"
+  export DOCS_BASE
+fi
+```
+
+Derives the site base path from the GitHub repository name (e.g., `robinmordasiewicz/my-docs` becomes `/my-docs`).
+
+### Step 6: Build
+
+```sh
+npm run build
+```
+
+Runs `astro build`, producing static output in `/app/dist/`.
+
+### Step 7: Copy Output
+
+```sh
+if [ -d "$OUTPUT_DIR" ]; then
+  cp -r /app/dist/* "$OUTPUT_DIR"/
+fi
+```
+
+Copies the built site to the output mount point.
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CONTENT_DIR` | `/content/docs` | Path to the mounted content directory |
+| `OUTPUT_DIR` | `/output` | Path where the built site is copied |
+| `DOCS_TITLE` | *(extracted from index.mdx)* | Site title passed to the Astro config |
+| `DOCS_BASE` | *(derived from `GITHUB_REPOSITORY`)* | Base path for the site (e.g., `/my-docs`) |
+| `GITHUB_REPOSITORY` | *(set by GitHub Actions)* | `owner/repo` string used to derive `DOCS_BASE` |
+
+## Local Usage
+
+To build documentation locally using Docker:
+
+```sh
+docker run --rm \
+  -v "$(pwd)/docs:/content/docs" \
+  -v "$(pwd)/output:/output" \
+  ghcr.io/robinmordasiewicz/f5xc-docs-builder:latest
+```
+
+This mounts the local `docs/` directory as content and writes the built site to `output/`.
+
+## Image Registry
+
+The image is published to GitHub Container Registry:
+
+```
+ghcr.io/robinmordasiewicz/f5xc-docs-builder
+```
+
+Two tags are pushed on every build:
+
+| Tag | Description |
+|-----|-------------|
+| `latest` | Most recent build from `main` |
+| `<sha>` | Full Git commit SHA for reproducible builds |
+
+See [CI/CD and Governance](/05-ci-cd/) for the workflow that builds and publishes the image.

--- a/docs/05-ci-cd.mdx
+++ b/docs/05-ci-cd.mdx
@@ -1,0 +1,130 @@
+---
+title: CI/CD and Governance
+description: GitHub Actions workflows, template sync, secrets, and branch protection.
+---
+
+The repository uses four GitHub Actions workflows and a centralized template system for governance.
+
+## Workflows
+
+| Workflow | File | Trigger | Purpose |
+|----------|------|---------|---------|
+| GitHub Pages Deploy | `github-pages-deploy.yml` | Push to `main`, manual dispatch | Builds and deploys the documentation site to GitHub Pages |
+| Build and Publish Docker Image | `build-image.yml` | Push to `main` (non-`.md`), daily cron, `repository_dispatch` | Builds the Docker image and pushes to GHCR |
+| Require Linked Issue | `require-linked-issue.yml` | Pull request events | Blocks PRs that do not reference a GitHub issue |
+| Enforce Repository Settings | `enforce-repo-settings.yml` | Every 6 hours, push to settings config, manual dispatch | Applies standardized repo settings from the template |
+
+### GitHub Pages Deploy
+
+```yaml
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+```
+
+Delegates to a reusable workflow in the template repository:
+
+```yaml
+jobs:
+  docs:
+    uses: robinmordasiewicz/f5xc-template/.github/workflows/docs-build-deploy.yml@main
+```
+
+Permissions: `contents: read`, `pages: write`, `id-token: write`. Uses concurrency group `pages` with `cancel-in-progress: true` to avoid stale deployments.
+
+### Build and Publish Docker Image
+
+```yaml
+on:
+  push:
+    branches: [main]
+    paths-ignore: ['**.md']
+  schedule:
+    - cron: '0 6 * * *'
+  repository_dispatch:
+    types: [rebuild-image]
+```
+
+Steps:
+1. Checkout code
+2. Log in to `ghcr.io` using `docker/login-action`
+3. Build and push using `docker/build-push-action` with context `.` and file `docker/Dockerfile`
+4. Tags: `ghcr.io/<owner>/<repo>:latest` and `ghcr.io/<owner>/<repo>:<sha>`
+
+The daily cron ensures the image stays current even without code changes (picks up dependency updates). The `repository_dispatch` event allows external systems to trigger a rebuild.
+
+Markdown-only changes (`**.md`) are excluded via `paths-ignore` to avoid unnecessary image rebuilds.
+
+### Require Linked Issue
+
+```yaml
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+```
+
+Uses `nearform-actions/github-action-check-linked-issues@v1` to enforce that every PR references a GitHub issue (e.g., `Closes #42` in the description). Dependabot PRs are excluded via:
+
+```yaml
+exclude-branches: "dependabot/**"
+```
+
+A custom message tells contributors the expected format if the check fails. See [CONTRIBUTING.md](https://github.com/robinmordasiewicz/f5xc-docs-builder/blob/main/CONTRIBUTING.md) for the full contributor workflow.
+
+### Enforce Repository Settings
+
+```yaml
+on:
+  schedule:
+    - cron: '0 */6 * * *'
+  push:
+    branches: [main]
+    paths:
+      - '.github/config/repo-settings.json'
+  workflow_dispatch:
+```
+
+Delegates to a reusable workflow in the template repository:
+
+```yaml
+jobs:
+  enforce:
+    uses: robinmordasiewicz/f5xc-template/.github/workflows/enforce-repo-settings-reusable.yml@main
+    secrets:
+      repo-admin-token: ${{ secrets.REPO_ADMIN_TOKEN }}
+```
+
+Runs every 6 hours and on changes to the settings config file. Applies branch protection rules, merge settings, and other repository configuration from `.github/config/repo-settings.json`.
+
+## Governance Model
+
+### Centralized Template
+
+The `robinmordasiewicz/f5xc-template` repository is the single source of truth for:
+
+- Reusable workflow definitions (docs deploy, repo settings enforcement)
+- Managed files synced across all repos in the organization
+- Standard configurations and branch protection rules
+
+This builder and all content repos inherit their CI/CD behavior from the template.
+
+### Managed File Sync
+
+The template repository can push managed files (like workflow definitions and config files) to downstream repos. This keeps all repositories aligned without manual updates. The sync runs via a separate workflow in the template repo.
+
+### Branch Protection
+
+The enforce-repo-settings workflow applies branch protection rules from the template, including:
+
+- Required status checks before merge
+- Required linked issue check
+- Squash merge preferred
+- Auto-delete head branches after merge
+
+## Secrets
+
+| Secret | Source | Purpose |
+|--------|--------|---------|
+| `GITHUB_TOKEN` | Automatic (GitHub) | Used by most workflows for checkout, package publishing, and API calls |
+| `REPO_ADMIN_TOKEN` | Manual (repository secret) | Required by enforce-repo-settings to modify branch protection and repo settings (needs admin scope) |

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,0 +1,50 @@
+---
+title: f5xc Docs Builder
+description: Developer documentation for the centralized documentation build system.
+template: splash
+hero:
+  tagline: A containerized Astro + Starlight build system that turns any content repo into a branded documentation site.
+  actions:
+    - text: Get Started
+      link: /01-architecture/
+      icon: right-arrow
+      variant: primary
+    - text: View on GitHub
+      link: https://github.com/robinmordasiewicz/f5xc-docs-builder
+      icon: external
+      variant: minimal
+sidebar:
+  hidden: true
+---
+
+import { Card, CardGrid } from '@astrojs/starlight/components';
+
+## Developer Guides
+
+<CardGrid>
+  <Card title="Architecture" icon="setting">
+    Content injection model, theme system, directory layout, and build pipeline.
+    [Read more &rarr;](/01-architecture/)
+  </Card>
+  <Card title="Placeholder System" icon="pencil">
+    Token format, state management, DOM walker, and how to add new placeholders.
+    [Read more &rarr;](/02-placeholder-system/)
+  </Card>
+  <Card title="Mermaid Diagrams" icon="document">
+    Remark plugin, client-side CDN rendering, and placeholder substitution in diagrams.
+    [Read more &rarr;](/03-mermaid/)
+  </Card>
+  <Card title="Docker Build" icon="rocket">
+    Dockerfile layers, entrypoint orchestration, environment variables, and local usage.
+    [Read more &rarr;](/04-docker/)
+  </Card>
+  <Card title="CI/CD and Governance" icon="approve-check-circle">
+    GitHub Actions workflows, template sync, secrets, and branch protection.
+    [Read more &rarr;](/05-ci-cd/)
+  </Card>
+</CardGrid>
+
+## Other Resources
+
+- [Content Author Migration Guide](https://github.com/robinmordasiewicz/f5xc-docs-builder/blob/main/MIGRATION.md) — frontmatter, imports, preview, and content structure
+- [Contributing Guide](https://github.com/robinmordasiewicz/f5xc-docs-builder/blob/main/CONTRIBUTING.md) — issue → branch → PR workflow and governance rules


### PR DESCRIPTION
## Summary
- Add the `docs/` directory with 6 MDX files describing the project architecture
- Without these files the Pages deploy workflow fails because the container has no content to build

## Test plan
- [ ] CI passes
- [ ] Pages deploy workflow succeeds after merge

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)