### PR TITLE
fix: only rebuild Docker image when Dockerfile or package files change

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -2,7 +2,10 @@ name: Build and Publish Docker Image
 on:
   push:
     branches: [main]
-    paths-ignore: ['**.md']
+    paths:
+      - 'docker/**'
+      - 'package.json'
+      - 'package-lock.json'
   schedule:
     - cron: '0 6 * * *'
   repository_dispatch:


### PR DESCRIPTION
## Summary
- Switch from `paths-ignore` to `paths` filter on the Docker build workflow
- Image only rebuilds when `docker/**`, `package.json`, or `package-lock.json` change
- Daily schedule and `repository_dispatch` triggers unchanged

## Test plan
- [ ] CI passes
- [ ] Pushing docs-only changes no longer triggers a Docker build
- [ ] Pushing Dockerfile changes still triggers a build

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)