### PR TITLE
fix: use relative links in index.mdx for base path compatibility

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -6,7 +6,7 @@ hero:
   tagline: A containerized Astro + Starlight build system that turns any content repo into a branded documentation site.
   actions:
     - text: Get Started
-      link: /01-architecture/
+      link: ./01-architecture/
       icon: right-arrow
       variant: primary
     - text: View on GitHub
@@ -24,23 +24,23 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 <CardGrid>
   <Card title="Architecture" icon="setting">
     Content injection model, theme system, directory layout, and build pipeline.
-    [Read more &rarr;](/01-architecture/)
+    [Read more &rarr;](./01-architecture/)
   </Card>
   <Card title="Placeholder System" icon="pencil">
     Token format, state management, DOM walker, and how to add new placeholders.
-    [Read more &rarr;](/02-placeholder-system/)
+    [Read more &rarr;](./02-placeholder-system/)
   </Card>
   <Card title="Mermaid Diagrams" icon="document">
     Remark plugin, client-side CDN rendering, and placeholder substitution in diagrams.
-    [Read more &rarr;](/03-mermaid/)
+    [Read more &rarr;](./03-mermaid/)
   </Card>
   <Card title="Docker Build" icon="rocket">
     Dockerfile layers, entrypoint orchestration, environment variables, and local usage.
-    [Read more &rarr;](/04-docker/)
+    [Read more &rarr;](./04-docker/)
   </Card>
   <Card title="CI/CD and Governance" icon="approve-check-circle">
     GitHub Actions workflows, template sync, secrets, and branch protection.
-    [Read more &rarr;](/05-ci-cd/)
+    [Read more &rarr;](./05-ci-cd/)
   </Card>
 </CardGrid>
 


### PR DESCRIPTION
## Summary
- Change absolute links (`/01-architecture/`) to relative (`./01-architecture/`) in `docs/index.mdx`
- Fixes 404 errors on the deployed GitHub Pages site where the base path `/f5xc-docs-builder/` was being bypassed

## Test plan
- [ ] CI passes
- [ ] After deploy, all links on https://robinmordasiewicz.github.io/f5xc-docs-builder/ resolve correctly

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)