### PR TITLE
feat: dispatch github-pages-deploy workflows after Docker image build

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -35,3 +35,22 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}:latest
             ghcr.io/${{ github.repository }}:${{ github.sha }}
+
+  dispatch:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch github-pages-deploy workflows
+        env:
+          GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN }}
+        run: |
+          repos=(
+            "robinmordasiewicz/f5xc-docs-theme"
+            "robinmordasiewicz/f5xc-docs-builder"
+            "robinmordasiewicz/f5xc-template"
+            "robinmordasiewicz/f5xc-ddos-administration-guide"
+          )
+          for repo in "${repos[@]}"; do
+            echo "Dispatching github-pages-deploy.yml to ${repo}"
+            gh workflow run github-pages-deploy.yml --repo "${repo}"
+          done


### PR DESCRIPTION
## Summary
Add dispatch job to build-image.yml that automatically triggers github-pages-deploy workflows in dependent repositories after successful Docker image build.

## Changes
- New 'dispatch' job in build-image.yml
- Depends on successful 'build' job completion
- Dispatches github-pages-deploy.yml to:
  - robinmordasiewicz/f5xc-docs-theme
  - robinmordasiewicz/f5xc-docs-builder
  - robinmordasiewicz/f5xc-template
  - robinmordasiewicz/f5xc-ddos-administration-guide
- Uses REPO_ADMIN_TOKEN for authentication

## Test plan
- Monitor GitHub Actions to verify dispatch jobs trigger
- Verify dependent repositories' github-pages-deploy workflows execute
- Confirm documentation sites rebuild successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #41