### PR TITLE
fix: add error handling to dispatch loop

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -50,7 +50,14 @@ jobs:
             "robinmordasiewicz/f5xc-template"
             "robinmordasiewicz/f5xc-ddos-administration-guide"
           )
+          failed=0
           for repo in "${repos[@]}"; do
             echo "Dispatching github-pages-deploy.yml to ${repo}"
-            gh workflow run github-pages-deploy.yml --repo "${repo}"
+            if ! gh workflow run github-pages-deploy.yml --repo "${repo}"; then
+              echo "::warning::Failed to dispatch to ${repo}"
+              failed=$((failed + 1))
+            fi
           done
+          if [ "$failed" -gt 0 ]; then
+            echo "::warning::${failed} dispatch(es) failed"
+          fi


### PR DESCRIPTION
## Summary
- Wraps each `gh workflow run` call in an `if ! ... ; then` guard
- Individual failures emit `::warning::` annotations instead of aborting the loop
- Reports total failure count at the end
- Ensures all 4 repos are always attempted

## Root Cause
The dispatch loop used default `set -e` behavior, so a single `gh workflow run` failure (HTTP 422 on f5xc-template) aborted the loop before reaching remaining repos.

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, trigger `build-image.yml` and verify all 4 repos are dispatched
- [ ] If any repo dispatch fails, verify it shows as a warning (not a hard failure)

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)