### PR TITLE
feat: add starlight-llms-txt plugin dependency and DOCS_DESCRIPTION extraction

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -28,6 +28,12 @@ if [ -z "$DOCS_TITLE" ] && [ -f /app/src/content/docs/index.mdx ]; then
   export DOCS_TITLE
 fi
 
+# Extract description from index.mdx frontmatter (if not set via env)
+if [ -z "$DOCS_DESCRIPTION" ] && [ -f /app/src/content/docs/index.mdx ]; then
+  DOCS_DESCRIPTION=$(grep -m1 '^description:' /app/src/content/docs/index.mdx | sed 's/description: *["]*//;s/["]*$//' || echo "")
+  export DOCS_DESCRIPTION
+fi
+
 # Extract base path from repo name (if not set via env)
 if [ -z "$DOCS_BASE" ] && [ -n "$GITHUB_REPOSITORY" ]; then
   DOCS_BASE="/${GITHUB_REPOSITORY#*/}"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "sharp": "^0.34.5",
+    "starlight-llms-txt": "^0.7.0",
     "unist-util-visit": "^5.1.0"
   }
 }


### PR DESCRIPTION
Closes #65

## Summary
- Add `starlight-llms-txt` ^0.7.0 dependency to `package.json` so child Astro sites can auto-generate `llms.txt` and `llms-full.txt` files for LLM documentation discovery
- Add `DOCS_DESCRIPTION` extraction from `index.mdx` frontmatter in `docker/entrypoint.sh` (follows the existing `DOCS_TITLE` pattern) so the plugin can include site descriptions

## Test plan
- [ ] Docker image rebuilds successfully with the new dependency
- [ ] `DOCS_DESCRIPTION` is correctly extracted from child repo `index.mdx` frontmatter
- [ ] After theme repo adds the plugin to `astro.config.mjs`, child sites generate `/llms.txt` and `/llms-full.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)