### PR TITLE
fix: add --legacy-peer-deps to entrypoint.sh npm commands

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -6,8 +6,8 @@ OUTPUT_DIR="${OUTPUT_DIR:-/output}"
 GENERATE_PDF="${GENERATE_PDF:-false}"
 
 # Update dependencies to latest versions
-npm install
-npm update
+npm install --legacy-peer-deps
+npm update --legacy-peer-deps
 
 # Copy Astro config from theme package
 cp /app/node_modules/f5xc-docs-theme/astro.config.mjs /app/astro.config.mjs


### PR DESCRIPTION
## Summary
- Adds `--legacy-peer-deps` flag to `npm install` and `npm update` in `docker/entrypoint.sh`
- Fixes ERESOLVE peer dependency conflict between `starlight-to-pdf` (requires `puppeteer@^23.10.4`) and root project (`puppeteer@^24.15.0`)
- Aligns runtime npm commands with the Dockerfile's `npm ci --legacy-peer-deps`

Closes #77

## Test plan
- [ ] Verify Docker image rebuilds successfully
- [ ] Confirm `github-pages-deploy.yml` workflow passes without ERESOLVE errors
- [ ] Check that `starlight-to-pdf` PDF generation still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)