### PR TITLE
fix: update f5xc-docs-theme dependency to non-scoped package

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "astro": "astro"
   },
   "dependencies": {
-    "f5xc-docs-theme": "npm:@robinmordasiewicz/f5xc-docs-theme@^1.1.0",
+    "f5xc-docs-theme": "^1.23.1",
     "@astrojs/react": "^4.4.2",
     "@astrojs/starlight": "^0.37.6",
     "@types/react": "^19.2.13",


### PR DESCRIPTION
## Summary
- Updates `f5xc-docs-theme` dependency from `npm:@robinmordasiewicz/f5xc-docs-theme@^1.1.0` to `^1.23.1`
- The theme now publishes to the non-scoped `f5xc-docs-theme` npm package
- The old scoped package `@robinmordasiewicz/f5xc-docs-theme` stopped at v1.22.0

## Test plan
- [ ] Docker image build succeeds with the new dependency
- [ ] Built site correctly applies theme v1.23.1 features (hidden index pages)

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)