### PR TITLE
feat: add Scalar API Reference React component for inline rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "f5xc-docs-theme": "^1.24.1",
     "@astrojs/react": "^4.4.2",
+    "@scalar/api-reference-react": "^0.8.51",
     "@astrojs/starlight": "^0.37.6",
     "@types/react": "^19.2.13",
     "@types/react-dom": "^19.2.3",

--- a/src/components/ScalarApiViewer.tsx
+++ b/src/components/ScalarApiViewer.tsx
@@ -1,0 +1,22 @@
+import { ApiReferenceReact } from '@scalar/api-reference-react'
+import '@scalar/api-reference-react/style.css'
+
+interface Props {
+  specUrl: string
+  title?: string
+}
+
+export default function ScalarApiViewer({ specUrl, title }: Props) {
+  return (
+    <ApiReferenceReact
+      configuration={{
+        spec: { url: specUrl },
+        theme: 'kepler',
+        darkMode: true,
+        defaultOpenAllTags: false,
+        hideDownloadButton: false,
+        metaData: title ? { title } : undefined,
+      }}
+    />
+  )
+}

--- a/src/components/ScalarApiViewerWrapper.astro
+++ b/src/components/ScalarApiViewerWrapper.astro
@@ -1,0 +1,26 @@
+---
+import ScalarApiViewer from './ScalarApiViewer.tsx';
+
+interface Props {
+  specUrl: string;
+  title?: string;
+}
+
+const { specUrl, title } = Astro.props;
+---
+
+<div class="scalar-viewer-container">
+  <ScalarApiViewer specUrl={specUrl} title={title} client:only="react" />
+</div>
+
+<style is:global>
+  .scalar-viewer-container {
+    margin-block: 1rem;
+    border-radius: 0.5rem;
+    overflow: hidden;
+    min-height: 600px;
+  }
+  .scalar-viewer-container .scalar-app {
+    max-width: 100%;
+  }
+</style>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,9 @@
   "extends": "astro/tsconfigs/strict",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "jsxImportSource": "react"
+    "jsxImportSource": "react",
+    "paths": {
+      "@components/*": ["./src/components/*"]
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Add `@scalar/api-reference-react` dependency for inline API viewer rendering
- Add `@components/*` path alias in `tsconfig.json` for MDX imports from content repos
- Create `ScalarApiViewer.tsx` React component wrapping Scalar with kepler theme and dark mode
- Create `ScalarApiViewerWrapper.astro` Astro island wrapper using `client:only="react"` pattern

## Test plan
- [ ] Import `ScalarApiViewerWrapper.astro` from MDX via `@components/` alias
- [ ] Verify Scalar renders inline with Starlight chrome (header, sidebar, breadcrumbs visible)
- [ ] Confirm no double scrollbar issue
- [ ] Test dark mode and kepler theme match existing standalone viewer

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)