### PR TITLE
fix: prepend Astro base path to Scalar spec URL for project sites

### DIFF
--- a/src/components/ScalarApiViewerWrapper.astro
+++ b/src/components/ScalarApiViewerWrapper.astro
@@ -7,10 +7,14 @@ interface Props {
 }
 
 const { specUrl, title } = Astro.props;
+
+// Prepend Astro base path so runtime fetch() resolves correctly on project sites
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+const resolvedUrl = specUrl.startsWith('/') ? `${base}${specUrl}` : specUrl;
 ---
 
 <div class="scalar-viewer-container">
-  <ScalarApiViewer specUrl={specUrl} title={title} client:only="react" />
+  <ScalarApiViewer specUrl={resolvedUrl} title={title} client:only="react" />
 </div>
 
 <style is:global>


### PR DESCRIPTION
## Summary
- Use `import.meta.env.BASE_URL` in `ScalarApiViewerWrapper.astro` to prepend the base path to the spec URL
- Fixes "Document could not be loaded" error on GitHub Pages project sites where base path is not `/`

## Test plan
- [ ] Deploy to a project site (e.g. `github.io/repo-name/`) and verify Scalar loads the spec correctly
- [ ] Verify still works when base path is `/` (no double slash)

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)