### PR TITLE
fix: Copy content.config.ts from theme at runtime (DRY)

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -9,8 +9,9 @@ GENERATE_PDF="${GENERATE_PDF:-false}"
 npm install --legacy-peer-deps
 npm update --legacy-peer-deps
 
-# Copy Astro config from theme package
+# Copy Astro config from theme package (single source of truth)
 cp /app/node_modules/f5xc-docs-theme/astro.config.mjs /app/astro.config.mjs
+cp /app/node_modules/f5xc-docs-theme/src/content.config.ts /app/src/content.config.ts
 
 # Patch: ensure customCss is initialized (workaround for theme plugin bug)
 sed -i "s/title: process.env.DOCS_TITLE || 'Documentation',/title: process.env.DOCS_TITLE || 'Documentation',\n      customCss: [],/" /app/astro.config.mjs

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,7 +1,0 @@
-import { defineCollection } from 'astro:content';
-import { docsLoader } from '@astrojs/starlight/loaders';
-import { docsSchema } from '@astrojs/starlight/schema';
-
-export const collections = {
-  docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
-};


### PR DESCRIPTION
## Summary

- Remove duplicate `src/content.config.ts` from builder repo
- Add `cp` command in `docker/entrypoint.sh` to copy `content.config.ts` from the `f5xc-docs-theme` npm package at runtime
- Follows the same pattern already used for `astro.config.mjs`

This establishes the theme repo as the single source of truth for all Astro/Starlight configuration files, eliminating duplication that could drift out of sync.

## Test plan

- [ ] Docker build succeeds
- [ ] `entrypoint.sh` copies both `astro.config.mjs` and `content.config.ts` from theme package
- [ ] Downstream docs sites build and generate all HTML pages correctly

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)