### PR TITLE
fix: sync Scalar API viewer with Starlight theme toggle

### DIFF
--- a/src/components/ScalarApiViewer.tsx
+++ b/src/components/ScalarApiViewer.tsx
@@ -12,7 +12,7 @@ export default function ScalarApiViewer({ specUrl, title }: Props) {
       configuration={{
         spec: { url: specUrl },
         theme: 'kepler',
-        darkMode: true,
+        hideDarkModeToggle: true,
         defaultOpenAllTags: false,
         hideDownloadButton: false,
         metaData: title ? { title } : undefined,

--- a/src/components/ScalarApiViewerWrapper.astro
+++ b/src/components/ScalarApiViewerWrapper.astro
@@ -17,6 +17,37 @@ const resolvedUrl = specUrl.startsWith('/') ? `${base}${specUrl}` : specUrl;
   <ScalarApiViewer specUrl={resolvedUrl} title={title} client:only="react" />
 </div>
 
+<script>
+  function syncScalarTheme() {
+    const theme = document.documentElement.dataset.theme || 'dark';
+    const isDark = theme !== 'light';
+    const container = document.querySelector('.scalar-viewer-container');
+    if (container) {
+      container.classList.toggle('dark-mode', isDark);
+      container.classList.toggle('light-mode', !isDark);
+    }
+  }
+
+  // Strip dark-mode/light-mode from <body> whenever Scalar adds them
+  const bodyObserver = new MutationObserver(() => {
+    const body = document.body;
+    if (body.classList.contains('dark-mode') || body.classList.contains('light-mode')) {
+      body.classList.remove('dark-mode', 'light-mode');
+      syncScalarTheme();
+    }
+  });
+  bodyObserver.observe(document.body, { attributes: true, attributeFilter: ['class'] });
+
+  // Watch Starlight data-theme changes and sync container class
+  const themeObserver = new MutationObserver(() => {
+    syncScalarTheme();
+  });
+  themeObserver.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
+
+  // Initial sync
+  syncScalarTheme();
+</script>
+
 <style is:global>
   .scalar-viewer-container {
     margin-block: 1rem;


### PR DESCRIPTION
## Summary
- Remove hardcoded `darkMode: true` from Scalar config, add `hideDarkModeToggle: true`
- Add MutationObservers to intercept Scalar's `<body>` class pollution and relocate theme classes to `.scalar-viewer-container`
- Watch Starlight's `data-theme` attribute to keep viewer in sync on toggle

Companion PR: robinmordasiewicz/f5xc-docs-theme#208 (defensive CSS)

Closes #118

## Test plan
- [ ] Load any API reference page and confirm Scalar renders in dark mode
- [ ] Toggle Starlight to Light — entire page including Scalar should switch
- [ ] Toggle back to Dark — should revert cleanly
- [ ] Inspect: `document.body.classList` should NOT contain `dark-mode` or `light-mode`
- [ ] Inspect: `.scalar-viewer-container` should have the correct mode class
- [ ] Rapid toggle several times — no visual glitches
- [ ] Standalone viewer (Full Screen link) still works dark-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)