### PR TITLE
chore: remove obsolete sed customCss patch from entrypoint

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -13,9 +13,6 @@ npm update --legacy-peer-deps
 cp /app/node_modules/f5xc-docs-theme/astro.config.mjs /app/astro.config.mjs
 cp /app/node_modules/f5xc-docs-theme/src/content.config.ts /app/src/content.config.ts
 
-# Patch: ensure customCss is initialized (workaround for theme plugin bug)
-sed -i "s/title: process.env.DOCS_TITLE || 'Documentation',/title: process.env.DOCS_TITLE || 'Documentation',\n      customCss: [],/" /app/astro.config.mjs
-
 # Inject content
 if [ -d "$CONTENT_DIR" ]; then
   cp -r "$CONTENT_DIR"/* /app/src/content/docs/

--- a/docs/04-docker.mdx
+++ b/docs/04-docker.mdx
@@ -57,9 +57,10 @@ Ensures the theme package and all dependencies are at their latest compatible ve
 
 ```sh
 cp /app/node_modules/f5xc-docs-theme/astro.config.mjs /app/astro.config.mjs
+cp /app/node_modules/f5xc-docs-theme/src/content.config.ts /app/src/content.config.ts
 ```
 
-Pulls `astro.config.mjs` from the theme package into the project root. This is the only Astro config the build uses — see [Architecture](../01-architecture/) for the theme system design.
+Copies `astro.config.mjs` and `content.config.ts` from the theme package. The theme is the single source of truth for Astro configuration — see [Architecture](../01-architecture/) for the theme system design.
 
 ### Step 3: Inject Content
 
@@ -151,6 +152,7 @@ When working on the builder itself (components, plugins, theme integration), you
 ```sh
 npm ci
 cp node_modules/f5xc-docs-theme/astro.config.mjs astro.config.mjs
+cp node_modules/f5xc-docs-theme/src/content.config.ts src/content.config.ts
 # Copy some test content into the content collection
 cp -r /path/to/test-content/* src/content/docs/
 DOCS_TITLE="Dev Test" npx astro dev --host
@@ -159,7 +161,7 @@ DOCS_TITLE="Dev Test" npx astro dev --host
 Open `http://localhost:4321`. Hot module replacement (HMR) works for component and plugin changes.
 
 :::note
-`astro.config.mjs` comes from the theme package and is not version-controlled in this repo. You must copy it from `node_modules` before running the dev server. The file is overwritten on each build by `entrypoint.sh`.
+`astro.config.mjs` and `content.config.ts` come from the theme package and are not version-controlled in this repo. You must copy them from `node_modules` before running the dev server. The entrypoint handles this automatically in Docker builds.
 :::
 
 :::note

--- a/docs/06-content-authors.mdx
+++ b/docs/06-content-authors.mdx
@@ -36,7 +36,6 @@ docker run --rm -it \
     npm install --legacy-peer-deps && npm update --legacy-peer-deps
     cp /app/node_modules/f5xc-docs-theme/astro.config.mjs /app/astro.config.mjs
     cp /app/node_modules/f5xc-docs-theme/src/content.config.ts /app/src/content.config.ts
-    sed -i "s/title: process.env.DOCS_TITLE || '\''Documentation'\'',/title: process.env.DOCS_TITLE || '\''Documentation'\'',\n      customCss: [],/" /app/astro.config.mjs
     cp -r /content/docs/* /app/src/content/docs/
     DOCS_TITLE=$(grep -m1 "^title:" /app/src/content/docs/index.mdx | sed "s/title: *[\"]*//;s/[\"]*$//") \
     npx astro dev --host
@@ -45,7 +44,7 @@ docker run --rm -it \
 
 Open `http://localhost:4321` in your browser once the server starts.
 
-This command mirrors the steps from `entrypoint.sh` — install dependencies, copy the theme config and content schema, patch `customCss`, inject your content — then starts a dev server instead of building.
+This command mirrors the steps from `entrypoint.sh` — update dependencies, copy the theme config (single source of truth), inject your content, extract the title — then starts a dev server instead of building.
 
 :::note
 File changes on your host require restarting the container. The volume is copied into the content collection directory at startup, not symlinked, so Astro's file watcher does not see host-side edits. Stop the container with `Ctrl+C` and re-run the command to pick up changes.


### PR DESCRIPTION
The theme plugin now handles customCss initialization via config:setup hook, making the sed workaround unnecessary.

## Changes
- Remove 3-line sed patch from docker/entrypoint.sh
- Update docs/04-docker.mdx to document both astro.config.mjs and content.config.ts copy steps
- Update docs/06-content-authors.mdx example and description to remove sed patch
- Clarify that theme is single source of truth for config

## Impact
- Simplified entrypoint.sh (removing technical debt)
- Better documentation of config initialization
- Cleaner development workflow

Closes #123