### PR TITLE
fix: add concurrency settings to build-image workflow

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -11,6 +11,10 @@ on:
   repository_dispatch:
     types: [rebuild-image]
 
+concurrency:
+  group: docker-build
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add `concurrency` group with `cancel-in-progress: true` to `build-image.yml`
- Prevents duplicate multi-arch Docker builds from running in parallel when multiple `repository_dispatch` events arrive close together
- Only the latest build matters since it always pushes the `:latest` tag

Closes #147

## Test plan
- [ ] CI passes
- [ ] Next time multiple dispatches arrive, only one Docker build runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)